### PR TITLE
WorldGen Changes

### DIFF
--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_amber_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_amber_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:amber_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_apatite_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_apatite_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:apatite_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_cinnabar_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_cinnabar_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:cinnabar_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_gallium_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_gallium_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:gallium_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_obsidian_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_obsidian_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:obsidian_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_onyx_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_onyx_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:onyx_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_peridot_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_peridot_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:peridot_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_platinum_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_platinum_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:platinum_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_ruby_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_ruby_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:ruby_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/eternalores/neoforge/biome_modifier/add_sapphire_ore.json
+++ b/kubejs/data/eternalores/neoforge/biome_modifier/add_sapphire_ore.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "eternalores:sapphire_ore_placed",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/bauxite.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/bauxite.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:bauxite",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/deep_nickel.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/deep_nickel.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:deep_nickel",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/lead.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/lead.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:lead",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/mineral_veins.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/mineral_veins.json
@@ -1,0 +1,8 @@
+{
+    "type": "neoforge:none",
+    "biomes": {
+    "type": "neoforge:any"
+    },
+    "features": "immersiveengineering:mineral_veins",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/nickel.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/nickel.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:nickel",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/silver.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/silver.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:silver",
+    "step": "underground_ores"
+}

--- a/kubejs/data/immersiveengineering/neoforge/biome_modifier/uranium.json
+++ b/kubejs/data/immersiveengineering/neoforge/biome_modifier/uranium.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:none",
+    "biomes": "#minecraft:is_overworld",
+    "features": "immersiveengineering:uranium",
+    "step": "underground_ores"
+}

--- a/kubejs/data/mekanism/neoforge/biome_modifier/fluorite.json
+++ b/kubejs/data/mekanism/neoforge/biome_modifier/fluorite.json
@@ -1,0 +1,6 @@
+{
+"type":"neoforge:none",
+"biomes":"#mekanism:spawn_ores",
+"features":["mekanism:ore_fluorite_normal","mekanism:ore_fluorite_buried"],
+"step":"underground_ores"
+}

--- a/kubejs/data/mekanism/neoforge/biome_modifier/lead.json
+++ b/kubejs/data/mekanism/neoforge/biome_modifier/lead.json
@@ -1,0 +1,6 @@
+{
+"type":"neoforge:none",
+"biomes":"#mekanism:spawn_ores",
+"features":"mekanism:ore_lead_normal",
+"step":"underground_ores"
+}

--- a/kubejs/data/mekanism/neoforge/biome_modifier/osmium.json
+++ b/kubejs/data/mekanism/neoforge/biome_modifier/osmium.json
@@ -1,0 +1,6 @@
+{
+"type":"neoforge:none",
+"biomes":"#mekanism:spawn_ores",
+"features":["mekanism:ore_osmium_upper","mekanism:ore_osmium_middle","mekanism:ore_osmium_small"],
+"step":"underground_ores"
+}

--- a/kubejs/data/mekanism/neoforge/biome_modifier/tin.json
+++ b/kubejs/data/mekanism/neoforge/biome_modifier/tin.json
@@ -1,0 +1,6 @@
+{
+"type":"neoforge:none",
+"biomes":"#mekanism:spawn_ores",
+"features":["mekanism:ore_tin_small", "mekanism:ore_tin_large"],
+"step":"underground_ores"
+}

--- a/kubejs/data/mekanism/neoforge/biome_modifier/uranium.json
+++ b/kubejs/data/mekanism/neoforge/biome_modifier/uranium.json
@@ -1,0 +1,6 @@
+{
+"type":"neoforge:none",
+"biomes":"#mekanism:spawn_ores",
+"features":["mekanism:ore_uranium_small","mekanism:ore_uranium_buried"],
+"step":"underground_ores"
+}


### PR DESCRIPTION
Added just a few .json files to remove worldgen from Biome_Modifier

- Removed unused Eternal Ores ores

- Removed Tin, Uranium, Lead, Fluorite and Osmium worldgen from Mekanism

- Removed Nickel/Deepslate variant, Silver, Uranium, Bauxite and Lead worldgen from Immersive Engineering