### PR TITLE
MA fixes and other changes

### DIFF
--- a/config/almostunified/unification/materials.json
+++ b/config/almostunified/unification/materials.json
@@ -6,7 +6,8 @@
     "mekanism",
     "railcraft",
     "forcecraft",
-    "immersiveengineering"
+    "immersiveengineering",
+    "oritech"
   ],
   "priority_overrides": {},
   "stone_variants": [

--- a/kubejs/server_scripts/mystical_agriculture/essence_to_material/certus_essence.js
+++ b/kubejs/server_scripts/mystical_agriculture/essence_to_material/certus_essence.js
@@ -1,0 +1,56 @@
+/* 
+This script is property of Catalyst Studios for use in the modpack Little Bit Large. It is under the All Rights Reserved license.
+It cannot be used or modified outside of Catalyst Studios without explicit permission from Catalyst Studios.
+*/
+
+ServerEvents.recipes( catalyst => {
+
+    //Applied Flux Press
+    catalyst.shaped(
+        Item.of('appflux:energy_processor_press'),
+    [
+        'AAA',
+        'ABA',
+        'AAA'
+    ],
+    {
+        A: 'mysticalagriculture:certus_quartz_essence',
+        B: 'appflux:charged_redstone'
+    }
+)
+    
+    //AdvancedAE Press
+    catalyst.shaped(
+        Item.of('advanced_ae:quantum_processor_press'), 
+    [
+        'AAA',
+        'ABA',
+        'AAA'
+    ],
+    {
+        A: 'mysticalagriculture:certus_quartz_essence',
+        B: 'advanced_ae:shattered_singularity'
+    }
+)
+
+    //ExtendedAE Press
+    catalyst.shaped(
+        Item.of('extendedae:concurrent_processor_press'), 
+    [
+        'AAA',
+        'ABA',
+        'AAA'
+    ],
+    {
+        A: 'mysticalagriculture:certus_quartz_essence',
+        B: 'extendedae:entro_crystal'
+    }
+)
+
+})
+
+
+/* 
+This script is property of Catalyst Studios for use in the modpack Little Bit Large. It is under the All Rights Reserved license.
+It cannot be used or modified outside of Catalyst Studios without explicit permission from Catalyst Studios.
+*/

--- a/kubejs/server_scripts/mystical_agriculture/essence_to_material/rubber_essence.js
+++ b/kubejs/server_scripts/mystical_agriculture/essence_to_material/rubber_essence.js
@@ -1,0 +1,39 @@
+/* 
+This script is property of Catalyst Studios for use in the modpack Little Bit Large. It is under the All Rights Reserved license.
+It cannot be used or modified outside of Catalyst Studios without explicit permission from Catalyst Studios.
+*/
+
+ServerEvents.recipes( catalyst => {
+
+    //Industrial Foregoing Dry Rubber
+    catalyst.shaped(
+        Item.of('industrialforegoing:dryrubber', 6),
+    [
+        '   ',
+        'AAA',
+        '   '
+    ],
+    {
+        A: 'mysticalagriculture:rubber_essence'
+    }
+)
+    
+    //Productive Trees Rubber
+    catalyst.shaped(
+        Item.of('productivetrees:cured_rubber', 6), 
+    [
+        ' A ',
+        ' A ',
+        ' A '
+    ],
+    {
+        A: 'mysticalagriculture:rubber_essence'
+    }
+)
+})
+
+
+/* 
+This script is property of Catalyst Studios for use in the modpack Little Bit Large. It is under the All Rights Reserved license.
+It cannot be used or modified outside of Catalyst Studios without explicit permission from Catalyst Studios.
+*/

--- a/kubejs/server_scripts/mystical_agriculture/seed_recipe_fixes.js
+++ b/kubejs/server_scripts/mystical_agriculture/seed_recipe_fixes.js
@@ -23,6 +23,99 @@ ServerEvents.recipes( catalyst => {
         ],
         result: { id: 'mysticalagriculture:wood_seeds' }
     })
+
+    //Rubber Seed
+    catalyst.remove({ output: 'mysticalagriculture:rubber_seeds' });
+
+    catalyst.custom({
+        type: 'mysticalagriculture:infusion',
+        input: { item: 'mysticalagriculture:prosperity_seed_base' },
+        ingredients: [
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:rubber' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:rubber' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:rubber' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:rubber' }
+        ],
+        result: { id: 'mysticalagriculture:rubber_seeds' }
+    })
+
+    //Silicon Seed
+    catalyst.remove({ output: 'mysticalagriculture:silicon_seeds' });
+
+    catalyst.custom({
+        type: 'mysticalagriculture:infusion',
+        input: { item: 'mysticalagriculture:prosperity_seed_base' },
+        ingredients: [
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:silicon' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:silicon' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:silicon' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:silicon' }
+        ],
+        result: { id: 'mysticalagriculture:silicon_seeds' }
+    })
+
+    //Sulfur Seed
+    catalyst.remove({ output: 'mysticalagriculture:sulfur_seeds' });
+
+    catalyst.custom({
+        type: 'mysticalagriculture:infusion',
+        input: { item: 'mysticalagriculture:prosperity_seed_base' },
+        ingredients: [
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/sulfur' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/sulfur' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/sulfur' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/sulfur' }
+        ],
+        result: { id: 'mysticalagriculture:sulfur_seeds' }
+    })
+
+    //Steel Seed (added this one due to Oritech adding a variation of steel)
+    catalyst.remove({ output: 'mysticalagriculture:steel_seeds' });
+
+    catalyst.custom({
+        type: 'mysticalagriculture:infusion',
+        input: { item: 'mysticalagriculture:prosperity_seed_base' },
+        ingredients: [
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:ingots/steel' },
+        { item: 'mysticalagriculture:imperium_essence' },
+        { tag: 'c:ingots/steel' },
+        { item: 'mysticalagriculture:imperium_essence' },
+        { tag: 'c:ingots/steel' },
+        { item: 'mysticalagriculture:imperium_essence' },
+        { tag: 'c:ingots/steel' }
+        ],
+        result: { id: 'mysticalagriculture:steel_seeds' }
+    })
+
+    //Saltpeter / Niter Seed (Not a fix, but recipe was not avaible)
+    catalyst.custom({
+        type: 'mysticalagriculture:infusion',
+        input: { item: 'mysticalagriculture:prosperity_seed_base' },
+        ingredients: [
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/niter' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/niter' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/niter' },
+        { item: 'mysticalagriculture:prudentium_essence' },
+        { tag: 'c:dusts/niter' }
+        ],
+        result: { id: 'mysticalagriculture:saltpeter_seeds' }
+    })
 })
 
 /* 

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -30,6 +30,9 @@ ServerEvents.tags('item', catalyst => {
     //Exalted Crafter Powered
     catalyst.add('c:exaltedcrafter/tier/2', 'evilcraft:exalted_crafter_wooden_empowered')
     catalyst.add('c:exaltedcrafter/tier/2', 'evilcraft:exalted_crafter_empowered')
+
+    //Rubber Tag
+    catalyst.add('c:rubber', 'industrialforegoing:dryrubber')
 })
 
 //block tags


### PR DESCRIPTION
- Added (c:rubber) tag to Dry Rubber from Industrial Foregoing and Cured Rubber from Productive Trees

- Rubber essence can now create both cured rubber and dry rubber

- Added a recipe for Saltpeter Seeds

- Added a few recipes using certus essence to create the other processor press from AdvancedAE, ExtendedAE and AppFlux

- Fixed other seed recipes not using their correct tags

- Added Oritech to AU unification folder