### PR TITLE
Fix "Smart Filter" Quest

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energetic.snbt
+++ b/config/ftbquests/quests/chapters/applied_energetic.snbt
@@ -50,6 +50,11 @@
 			y: 1.5d
 		}
 		{
+			dependencies: [
+				"6FF0A677B6BDD946"
+				"5D07E1630119890C"
+			]
+			dependency_requirement: "one_completed"
 			icon: {
 				id: "minecraft:emerald_ore"
 			}


### PR DESCRIPTION
Fixes Patriot's report of the "Smart Filter" quest being completed when any raw ore was picked up Adds the formation and annihilation plane as dependencies for this quest