### PR TITLE
feat(config): add ftb ultimine tag merge for menril logs

### DIFF
--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -1,0 +1,13 @@
+# Default config file that will be copied to saves\New World\serverconfig\ftbultimine-server.snbt if it doesn't exist!
+# Just copy any values you wish to override in here!
+
+{
+    misc: {
+        merge_tags: [
+            "minecraft:base_stone_overworld"
+            "c:*_ores"
+            "forge:ores/*"
+            "integrateddynamics:menril_log*"
+        ]
+    }
+}


### PR DESCRIPTION
Update that only adds a default config for ftb ultimine to treat menril logs and enriched menril logs as a match so that using ultimine on a menril tree will break the entire tree.

This config does not affect any other default settings for ultimine and only applies to new worlds created after updating it.  (the same change can be applied to any existing world in by adding `"integrateddynamics:menril_log*"` to misc/merge_tags in `<worldName>/serverconfig/ftbultimine-server.snbt`)